### PR TITLE
Fix launch p7zip desktop with arguments

### DIFF
--- a/7zDesktop
+++ b/7zDesktop
@@ -1,2 +1,11 @@
-#! /bin/sh
-"/snap/p7zip-desktop/current/usr/local/lib/p7zip/7zFM" "/home/$USER" "$@"
+#!/bin/bash
+
+if [ -z "$@" ]; then
+        if [ "$USER" == "root" ]; then 
+                "/snap/p7zip-desktop/current/usr/local/lib/p7zip/7zFM" "/root" 
+        else
+                "/snap/p7zip-desktop/current/usr/local/lib/p7zip/7zFM" "/home/$USER"
+        fi
+else
+        "/snap/p7zip-desktop/current/usr/local/lib/p7zip/7zFM" "$@"
+fi


### PR DESCRIPTION
Fix launch p7zip desktop with arguments, needs for open p7zip desktop with "open as" of desktop environment